### PR TITLE
Service refuses to start if apikey/template invalid

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/notify/config/NotifyConfgurationException.java
+++ b/src/main/java/uk/gov/ons/ctp/response/notify/config/NotifyConfgurationException.java
@@ -1,0 +1,22 @@
+package uk.gov.ons.ctp.response.notify.config;
+
+public class NotifyConfgurationException extends RuntimeException {
+    public NotifyConfgurationException() {
+    }
+
+    public NotifyConfgurationException(String message) {
+        super(message);
+    }
+
+    public NotifyConfgurationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public NotifyConfgurationException(Throwable cause) {
+        super(cause);
+    }
+
+    public NotifyConfgurationException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/uk/gov/ons/ctp/response/notify/config/NotifyConfiguration.java
+++ b/src/main/java/uk/gov/ons/ctp/response/notify/config/NotifyConfiguration.java
@@ -4,7 +4,9 @@ import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import uk.gov.service.notify.NotificationClient;
+import uk.gov.ons.ctp.response.notify.service.impl.ConfigurationAwareNotificationClient;
+import uk.gov.ons.ctp.response.notify.util.BitCalculator;
+import uk.gov.service.notify.NotificationClientApi;
 
 /**
  * Configuration specific to GOV.UK Notify
@@ -24,7 +26,32 @@ public class NotifyConfiguration {
    * @return the notificationClient
    */
   @Bean
-  public NotificationClient notificationClient() {
-    return new NotificationClient(apiKey);
+  public NotificationClientApi notificationClient() {
+    validate();
+    return new ConfigurationAwareNotificationClient(this);
+  }
+
+  /**
+   * Method to validate the gov.notify api key and template id.  RuntimeException thrown as there really is no point
+   * in this service continuing if the keys are bogus
+   * @throws RuntimeException
+   */
+  private void validate(){
+    BitCalculator bitCalc = new BitCalculator();
+
+    BitCalculator.KeyInfo keyInfo = bitCalc.analyseNotifyKey(this.apiKey);
+    if (!keyInfo.valid){
+      throw new NotifyConfgurationException("Invalid gov.notify API key: " + this.apiKey);
+    }
+
+    keyInfo = bitCalc.analyseUUID(this.onsSurveysRasEmailReminderTemplateId);
+    if (!keyInfo.valid) {
+      throw new NotifyConfgurationException("Invalid email reminder template id: " + this.onsSurveysRasEmailReminderTemplateId);
+    }
+
+    keyInfo = bitCalc.analyseUUID(this.censusUacSmsTemplateId);
+    if (!keyInfo.valid){
+      throw new NotifyConfgurationException("Invalid census UAC SMS template id: " + this.censusUacSmsTemplateId);
+    }
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/notify/service/impl/ConfigurationAwareNotificationClient.java
+++ b/src/main/java/uk/gov/ons/ctp/response/notify/service/impl/ConfigurationAwareNotificationClient.java
@@ -1,0 +1,108 @@
+package uk.gov.ons.ctp.response.notify.service.impl;
+
+import lombok.extern.slf4j.Slf4j;
+import uk.gov.ons.ctp.response.notify.config.NotifyConfiguration;
+import uk.gov.service.notify.*;
+
+import java.util.Map;
+
+/**
+ * This is a delegate class for NotificationClient that suppresses all calls to the actual NotificationClient if
+ * NotifyConfiguration.getEnabled() is false
+ */
+@Slf4j
+public class ConfigurationAwareNotificationClient implements NotificationClientApi {
+
+    private final NotifyConfiguration configuration;
+    private final NotificationClientApi realClient;
+
+    public ConfigurationAwareNotificationClient(NotifyConfiguration config, NotificationClientApi realClient) {
+        this.configuration = config;
+        this.realClient = realClient;
+    }
+
+    public ConfigurationAwareNotificationClient(NotifyConfiguration config) {
+        this(config, new NotificationClient(config.getApiKey()));
+    }
+
+    @Override
+    public SendEmailResponse sendEmail(String templateId, String emailAddress, Map<String, String> personalisation, String reference) throws NotificationClientException {
+        log.debug("sendEmail: {} - {} - {} - {}", templateId, emailAddress, personalisation, reference);
+
+        if (this.configuration.getEnabled()) {
+            return realClient.sendEmail(templateId, emailAddress, personalisation, reference);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public SendSmsResponse sendSms(String templateId, String phoneNumber, Map<String, String> personalisation, String reference) throws NotificationClientException {
+        log.debug("sendSms: {} - {} - {} - {}", templateId, phoneNumber, personalisation, reference);
+        if (this.configuration.getEnabled()) {
+            return realClient.sendSms(templateId, phoneNumber, personalisation, reference);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public Notification getNotificationById(String notificationId) throws NotificationClientException {
+        log.debug("getNotificationById: {}", notificationId);
+        if (this.configuration.getEnabled()) {
+            return realClient.getNotificationById(notificationId);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public NotificationList getNotifications(String status, String notification_type, String reference, String olderThanId) throws NotificationClientException {
+        log.debug("getNotifications: {}", status, notification_type, reference, olderThanId);
+        if (this.configuration.getEnabled()) {
+            return realClient.getNotifications(status, notification_type, reference, olderThanId);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public Template getTemplateById(String templateId) throws NotificationClientException {
+        log.debug("getTemplateById: {}", templateId);
+        if (this.configuration.getEnabled()) {
+            return realClient.getTemplateById(templateId);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public Template getTemplateVersion(String templateId, int version) throws NotificationClientException {
+        log.debug("getTemplateVersion: {}", templateId, version);
+        if (this.configuration.getEnabled()) {
+            return realClient.getTemplateVersion(templateId, version);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public TemplateList getAllTemplates(String templateType) throws NotificationClientException {
+        log.debug("getAllTemplates");
+        if (this.configuration.getEnabled()) {
+            return realClient.getAllTemplates(templateType);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public TemplatePreview generateTemplatePreview(String templateId, Map<String, String> personalisation) throws NotificationClientException {
+        log.debug("generateTemplatePreview: {} - {}", templateId, personalisation);
+        if (this.configuration.getEnabled()) {
+            return realClient.generateTemplatePreview(templateId, personalisation);
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/main/java/uk/gov/ons/ctp/response/notify/service/impl/NotifyServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/notify/service/impl/NotifyServiceImpl.java
@@ -34,7 +34,7 @@ public class NotifyServiceImpl implements NotifyService {
     private NotifyConfiguration notifyConfiguration;
 
     @Autowired
-    private NotificationClient notificationClient;
+    private NotificationClientApi notificationClient;
 
     public static final String FIRSTNAME_KEY = "firstname";
     public static final String IAC_KEY = "iac";
@@ -83,7 +83,7 @@ public class NotifyServiceImpl implements NotifyService {
             SendSmsResponse response = notificationClient.sendSms(templateId, phoneNumber, personalisationMap,
                     reference);
             log.debug("response = {}", response);
-            return response.getNotificationId();
+            return response == null ? null : response.getNotificationId();
         } else {
             // The xsd enforces to have either a phoneNumber OR an emailAddress
             log.debug("About to invoke sendEmail with templateId {} - emailAddress {} - personalisationMap "
@@ -91,7 +91,7 @@ public class NotifyServiceImpl implements NotifyService {
             SendEmailResponse response = notificationClient.sendEmail(templateId, emailAddress,
                 personalisationMap, reference);
             log.debug("response = {}", response);
-            return response.getNotificationId();
+            return response == null ? null : response.getNotificationId();
         }
     }
 
@@ -149,8 +149,13 @@ public class NotifyServiceImpl implements NotifyService {
             + " for actionId = {}", templateId, phoneNumber, personalisation, actionId);
 
         SendSmsResponse response = notificationClient.sendSms(templateId, phoneNumber, personalisation, null);
-        log.debug("status = {} for actionId = {}", notificationClient.getNotificationById(
-            response.getNotificationId().toString()).getStatus(), actionId);
+
+        if (response != null) {
+            log.debug("status = {} for actionId = {}", notificationClient.getNotificationById(
+                    response.getNotificationId().toString()).getStatus(), actionId);
+        } else {
+            log.debug("response is null for actionId {}", actionId);
+        }
 
         return new ActionFeedback(actionId,
             NOTIFY_SMS_SENT.length() <= SITUATION_MAX_LENGTH ?
@@ -185,8 +190,13 @@ public class NotifyServiceImpl implements NotifyService {
 
         SendEmailResponse response = notificationClient.sendEmail(templateId, emailAddress,
             personalisation, null);
-        Notification notif = notificationClient.getNotificationById(response.getNotificationId().toString());
-        log.debug("status = {} for actionId = {}", notif.getStatus(), actionId);
+
+        if (response != null) {
+            Notification notif = notificationClient.getNotificationById(response.getNotificationId().toString());
+            log.debug("status = {} for actionId = {}", notif.getStatus(), actionId);
+        } else {
+            log.debug("actionId = {}, response is null", actionId);
+        }
 
         return new ActionFeedback(actionId,
             NOTIFY_EMAIL_SENT.length() <= SITUATION_MAX_LENGTH ?

--- a/src/main/java/uk/gov/ons/ctp/response/notify/util/BitCalculator.java
+++ b/src/main/java/uk/gov/ons/ctp/response/notify/util/BitCalculator.java
@@ -1,0 +1,172 @@
+package uk.gov.ons.ctp.response.notify.util;
+
+import lombok.ToString;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.math.BigInteger;
+
+/**
+ * This is a simple class to take a gov.notify key or other arbitrary string representing a number and a radix and
+ * return the number of bits of data in the key. This is primarily for working out the validity of notify keys.
+ * @author innesm
+ */
+@ToString
+public class BitCalculator {
+
+    private static final Pattern KEY_REGEXP = Pattern.compile("^([^-]+)-(.*)$");
+
+    private static final int MINIMUM_KEY_BITS = 256;
+    private static final int UUID_BITS = 128;
+    private static final int HEX_RADIX = 16;
+
+    /**
+     * A bag of stuff holding details of the supplied data.  Could probably boil this down to just bits and valid.
+     */
+    public static class KeyInfo {
+        public final String inputString;
+        public final BigInteger value;
+        public final String valueStr;
+        public final String keyName;
+        public final int bits;
+        public final int radix;
+        public final boolean valid;
+
+        /**
+         * Constructor for immutable object
+         * @param aInputString String to analyse
+         * @param aValue Value represented by input string
+         * @param aValueStr Value portion of input string
+         * @param aKeyName Name of a key
+         * @param aBits Number of bits represented by data in input string
+         * @param aRadix Radix of number in input string
+         * @param aValid Validity flag
+         */
+        public KeyInfo(
+                final String aInputString,
+                final BigInteger aValue,
+                final String aValueStr,
+                final String aKeyName,
+                final int aBits,
+                final int aRadix,
+                final boolean aValid) {
+            this.inputString = aInputString;
+            this.value = aValue;
+            this.valueStr = aValueStr;
+            this.keyName = aKeyName;
+            this.bits = aBits;
+            this.radix = aRadix;
+            this.valid = aValid;
+        }
+    }
+
+    /**
+     * Parses a String into a KeyInfo structure.  If the isKey flag is set the String is a gov.notify key and the text
+     * up to the first hyphen is assumed to be the name of the key.  If the isKey flag is not set, the string is a
+     * number in base radix with optional hyphens to break it up.
+     * @param str string to parse
+     * @param isKey key flag to indicate whether the string is a gov.notify key
+     * @param radix the radix of the number portion
+     * @return a KeyInfo object showing the number of bits of data contained within the number portion of the supplied string
+     */
+    public KeyInfo analyse(final String str, final boolean isKey, final int radix) {
+        KeyInfo info = cleanString(str, isKey, radix);
+
+        if (info.valid) {
+            int numDigits = info.valueStr.length();
+            int bitsPerDigit = new Double(getBitsPerDigit(radix)).intValue();
+            int bits = ((numDigits * bitsPerDigit) >>> radix);
+            boolean valid = (isKey == false) || bits >= MINIMUM_KEY_BITS;
+
+            return new KeyInfo(info.inputString, info.value, info.valueStr, info.keyName, bits, info.radix, valid);
+        } else {
+            return info;
+        }
+    }
+
+    /**
+     * Analyse a number encoded as a hexadecimal string
+     * @param hexString A number encoded as a hex string
+     * @return an object showing the number of bits of data in the supplied string
+     */
+    public KeyInfo analyseHexNumber(final String hexString) {
+        return analyse(hexString, false, HEX_RADIX);
+
+    }
+
+    /**
+     * Analyse a potential UUID. If it's a valid hex number and there are exactly 128 bits, the returned structure
+     * will be have valid = true (otherwise false)
+     * @param hexString A number encoded as a hex string
+     * @return an object showing the number of bits of data in the supplied string and a flag showing whether it's a valid #
+     * UUID
+     */
+    public KeyInfo analyseUUID(final String hexString) {
+        final KeyInfo info = analyse(hexString, false, HEX_RADIX);
+
+        if (info.bits != UUID_BITS && info.valid == true) {
+            return new KeyInfo(info.inputString, info.value, info.valueStr, info.keyName, info.bits, info.radix, false);
+        } else {
+            return info;
+        }
+    }
+
+    /**
+     * Analyse a gov.notify key - a gov.notify key is a hex number with an alphanumeric prefix delimited by a hyphen
+     * @param key The string of the key
+     * @return an object showing the number of bits of data in the supplied key
+     */
+    public KeyInfo analyseNotifyKey(final String key) {
+        return analyse(key, true, HEX_RADIX);
+    }
+
+    /**
+     * A helper method to parse and tokenise a supplied string.  If it's a key it'll strip of everything to the first
+     * hyphen and use it as keyName otherwise it will parse the whole number
+     * @param str the string to clean
+     * @param isKey does the string represent a gov.notify key?
+     * @param radix teh radix for the number
+     * @return an object representing the cleaned and tokenised string
+     */
+    private KeyInfo cleanString(final String str, final boolean isKey, final int radix) {
+        final String keyName;
+        final String valueStr;
+
+        if (isKey) {
+            Matcher matcher = KEY_REGEXP.matcher(str);
+
+            if (matcher.find()) {
+                keyName = matcher.group(1);
+                valueStr = matcher.group(2);
+            } else {
+                return new KeyInfo(str, null, null, null, -1, radix, false);
+            }
+        } else {
+            keyName = null;
+            valueStr = str;
+        }
+
+        if (valueStr != null) {
+            String cleanValueStr = valueStr.replaceAll("-", "");
+
+            try {
+                BigInteger value = new BigInteger(cleanValueStr, radix);
+
+                return new KeyInfo(str, value, cleanValueStr, keyName, -1, radix,true);
+            } catch(NumberFormatException e) {
+                return new KeyInfo(str, null, cleanValueStr, keyName, -1, radix, false);
+            }
+        } else {
+            return new KeyInfo(str, null, null, keyName, -1, radix, false);
+        }
+    }
+
+    /**
+     * Method to get the bits per digit for a given radix
+     * @param radix The radix to calculate
+     * @return bits per digit
+     */
+    private static double getBitsPerDigit(int radix) {
+        return Math.log(radix) / Math.log(2) * Math.pow(2, radix);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -79,9 +79,9 @@ redelivery-policy:
 
 notify:
   enabled: false
-  apiKey: api-key-placeholder
-  censusUacSmsTemplateId: template-id-placeholder
-  onsSurveysRasEmailReminderTemplateId: template-id-placeholder
+  apiKey: dummykey-ffffffff-ffff-ffff-ffff-ffffffffffff-ffffffff-ffff-ffff-ffff-ffffffffffff
+  censusUacSmsTemplateId: ffffffff-ffff-ffff-ffff-ffffffffffff
+  onsSurveysRasEmailReminderTemplateId: ffffffff-ffff-ffff-ffff-ffffffffffff
 
 rabbitmq:
   username: guest

--- a/src/test/java/uk/gov/ons/ctp/response/notify/service/impl/ConfigurationAwareNotificationClientTests.java
+++ b/src/test/java/uk/gov/ons/ctp/response/notify/service/impl/ConfigurationAwareNotificationClientTests.java
@@ -1,0 +1,81 @@
+package uk.gov.ons.ctp.response.notify.service.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.ons.ctp.response.notify.config.NotifyConfiguration;
+import uk.gov.service.notify.NotificationClient;
+import uk.gov.service.notify.NotificationClientApi;
+import uk.gov.service.notify.NotificationClientException;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConfigurationAwareNotificationClientTests {
+    private static final String DUMMY_API_KEY = "dummykey-ffffffff-ffff-ffff-ffff-ffffffffffff-ffffffff-ffff-ffff-ffff-ffffffffffff";
+    private static final String DUMMY_TEMPLATE_ID = "ffffffff-ffff-ffff-ffff-ffffffffffff";
+
+    @Mock
+    private NotificationClient realNotificationClient;
+
+    @Mock
+    private NotifyConfiguration notifyConfiguration;
+
+    private NotificationClientApi testNotificationClient;
+
+    @Before
+    public void setup(){
+        when(notifyConfiguration.getApiKey()).thenReturn(DUMMY_API_KEY);
+        when(notifyConfiguration.getCensusUacSmsTemplateId()).thenReturn(DUMMY_TEMPLATE_ID);
+        when(notifyConfiguration.getOnsSurveysRasEmailReminderTemplateId()).thenReturn(DUMMY_TEMPLATE_ID);
+
+        this.testNotificationClient = new ConfigurationAwareNotificationClient(this.notifyConfiguration, this.realNotificationClient);
+    }
+
+    @Test
+    public void testAllApiEnabled() throws NotificationClientException {
+        when(notifyConfiguration.getEnabled()).thenReturn(true);
+
+        this.testNotificationClient.generateTemplatePreview(null, null);
+        verify(this.realNotificationClient, times(1)).generateTemplatePreview(any(), any());
+        this.testNotificationClient.getAllTemplates(null);
+        verify(this.realNotificationClient, times(1)).getAllTemplates(any());
+        this.testNotificationClient.getNotificationById(null);
+        verify(this.realNotificationClient, times(1)).getNotificationById(any());
+        this.testNotificationClient.getNotifications(null, null, null, null);
+        verify(this.realNotificationClient, times(1)).getNotifications(any(), any(), any(), any());
+        this.testNotificationClient.getTemplateById(null);
+        verify(this.realNotificationClient, times(1)).getTemplateById(any());
+        this.testNotificationClient.getTemplateVersion(null ,0);
+        verify(this.realNotificationClient, times(1)).getTemplateVersion(any(), anyInt());
+        this.testNotificationClient.sendEmail(null, null, null, null);
+        verify(this.realNotificationClient, times(1)).sendEmail(any(), any(), any(), any());
+        this.testNotificationClient.sendSms(null, null, null, null);
+        verify(this.realNotificationClient, times(1)).sendSms(any(), any(), any(), any());
+    }
+
+    @Test
+    public void testAllApiDisabled() throws NotificationClientException {
+        when(notifyConfiguration.getEnabled()).thenReturn(false);
+
+        this.testNotificationClient.generateTemplatePreview(null, null);
+        verify(this.realNotificationClient, never()).generateTemplatePreview(any(), any());
+        this.testNotificationClient.getAllTemplates(null);
+        verify(this.realNotificationClient, never()).getAllTemplates(any());
+        this.testNotificationClient.getNotificationById(null);
+        verify(this.realNotificationClient, never()).getNotificationById(any());
+        this.testNotificationClient.getNotifications(null, null, null, null);
+        verify(this.realNotificationClient, never()).getNotifications(any(), any(), any(), any());
+        this.testNotificationClient.getTemplateById(null);
+        verify(this.realNotificationClient, never()).getTemplateById(any());
+        this.testNotificationClient.getTemplateVersion(null ,0);
+        verify(this.realNotificationClient, never()).getTemplateVersion(any(), anyInt());
+        this.testNotificationClient.sendEmail(null, null, null, null);
+        verify(this.realNotificationClient, never()).sendEmail(any(), any(), any(), any());
+        this.testNotificationClient.sendSms(null, null, null, null);
+        verify(this.realNotificationClient, never()).sendSms(any(), any(), any(), any());
+    }
+}

--- a/src/test/java/uk/gov/ons/ctp/response/notify/util/BitCalculatorTests.java
+++ b/src/test/java/uk/gov/ons/ctp/response/notify/util/BitCalculatorTests.java
@@ -1,0 +1,72 @@
+package uk.gov.ons.ctp.response.notify.util;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.testng.Assert;
+
+public class BitCalculatorTests {
+
+    @Before
+    public void setup(){
+        this.bitCalculator = new BitCalculator();
+    }
+
+    @Test
+    public void testValidNotifyKey(){
+        BitCalculator.KeyInfo info  = this.bitCalculator.analyseNotifyKey("rmnotifygatewayfixes1-7c1b5868-f1d9-48af-a12f-b68d5e0905c2-2e58b9a4-d9bc-11e7-9296-cec278b6b50a");
+        Assert.assertTrue(info.valid);
+        Assert.assertEquals("rmnotifygatewayfixes1", info.keyName);
+        Assert.assertEquals(256, info.bits);
+    }
+
+    @Test
+    public void testInvalidNotifyKey(){
+        BitCalculator.KeyInfo info  = this.bitCalculator.analyseNotifyKey("rmnotifygatewayfixes1-7c1b5868-f1d9-48af-a12f-b68d5e0905c2");
+
+        Assert.assertFalse(info.valid);
+        Assert.assertEquals("rmnotifygatewayfixes1", info.keyName);
+        Assert.assertEquals(128, info.bits);
+    }
+
+    @Test
+    public void testDummyKey(){
+        BitCalculator.KeyInfo info  = this.bitCalculator.analyseNotifyKey("dummykey-ffffffff-ffff-ffff-ffff-ffffffffffff-ffffffff-ffff-ffff-ffff-ffffffffffff");
+
+        Assert.assertTrue(info.valid);
+        Assert.assertEquals("dummykey", info.keyName);
+        Assert.assertEquals(256, info.bits);
+    }
+
+    @Test
+    public void testBrokenKey(){
+        BitCalculator.KeyInfo info  = this.bitCalculator.analyseNotifyKey("brokenkey-qfffffff-ffff-ffff-ffff-ffffffffffff-ffffffff-ffff-ffff-ffff-ffffffffffff");
+
+        Assert.assertFalse(info.valid);
+        Assert.assertEquals("brokenkey", info.keyName);
+    }
+
+    @Test
+    public void testTemplateId(){
+        BitCalculator.KeyInfo info  = this.bitCalculator.analyseHexNumber("fb7b617a-d5ce-4c0c-812b-e0c3c3a29e2d");
+
+        Assert.assertTrue(info.valid);
+        Assert.assertEquals(128, info.bits);
+    }
+
+    @Test
+    public void testDummyTemplateId(){
+        BitCalculator.KeyInfo info  = this.bitCalculator.analyseHexNumber("ffffffff-ffff-ffff-ffff-ffffffffffff");
+
+        Assert.assertTrue(info.valid);
+        Assert.assertEquals(128, info.bits);
+    }
+
+    @Test
+    public void testBrokenTemplateId(){
+        BitCalculator.KeyInfo info  = this.bitCalculator.analyseHexNumber("this-is-not-a-hex-number");
+
+        Assert.assertFalse(info.valid);
+    }
+
+    private BitCalculator bitCalculator;
+}


### PR DESCRIPTION
Calling all closet Java developers ... 

- If either the API key is invalid or the 2 templated ids are invalid,
  the notifygateway service will throw a RuntimeException and fail to
  start
- There is now a wrapper around the
  NotificationClient (ConfigurationAwareNotificationClient) that
  suppresses all API calls to gov.notify if the application.yml item
  notify.enabled is false (this is the same feature flag Joe introduced).