### PR TITLE
Changes for maven release plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
+ARG JAR_FILE=notifygatewaysvc*.jar
 FROM openjdk:8u121-jre
 
-ADD target/notifygatewaysvc*.jar /opt/notifygatewaysvc.jar
+ARG JAR_FILE
+COPY target/$JAR_FILE /opt/notifygatewaysvc.jar
 
 ENTRYPOINT [ "sh", "-c", "java $JAVA_OPTS -jar /opt/notifygatewaysvc.jar" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-ARG JAR_FILE=notifygatewaysvc*.jar
 FROM openjdk:8u121-jre
 
-ARG JAR_FILE
+ARG JAR_FILE=notifygatewaysvc*.jar
 COPY target/$JAR_FILE /opt/notifygatewaysvc.jar
 
 ENTRYPOINT [ "sh", "-c", "java $JAVA_OPTS -jar /opt/notifygatewaysvc.jar" ]

--- a/pom.xml
+++ b/pom.xml
@@ -2,9 +2,8 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  <groupId>uk.gov.ons.ctp.product</groupId>
   <artifactId>notifygatewaysvc</artifactId>
-  <version>10.49.2-SNAPSHOT</version>
+  <version>10.49.4-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>CTP : NotifyGatewayService</name>
@@ -15,17 +14,16 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
 
-  <!-- Inherit parent BOM to control versions of dependencies and plugin version & config --> 
   <parent>
     <groupId>uk.gov.ons.ctp.product</groupId>
     <artifactId>rm-common-config</artifactId>
-    <version>10.49.2</version>
+    <version>10.49.8</version>
   </parent>
 
   <scm>
-    <connection>scm:git:git@github.com:ONSdigital/rm-notify-gateway.git</connection>
-    <developerConnection>scm:git:git@github.com:ONSdigital/rm-notify-gateway.git</developerConnection>
-    <url>git@github.com:ONSdigital/rm-notify-gateway.git</url>
+    <connection>scm:git:https://github.com/ONSdigital/rm-notify-gateway</connection>
+    <developerConnection>scm:git:https://github.com/ONSdigital/rm-notify-gateway</developerConnection>
+    <url>https://github.com/ONSdigital/rm-notify-gateway</url>
   </scm>
 
   <dependencies>
@@ -234,8 +232,10 @@
             </goals>
             <phase>package</phase>
             <configuration>
-              <finalName>docker-info-${project.artifactId}</finalName>
               <repository>sdcplatform/${project.artifactId}</repository>
+              <buildArgs>
+                <JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
+              </buildArgs>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
## What is it
These changes are driven to allow us to release artifacts in a much simpler way. Currently we have a bunch of shell scripts that we maintain to do releases when this is a core part of maven to be able to bump version, create tags and deploy artifacts.

* Bump versions and remove snapshot 
Release 13 was done on a branch where the version was incremented. The version change hasn't made it's way back into master yet so this change skips that version. We are also removing the snapshot versions.

* Using optional dockerfile buildArgs
We have been fighting with the `COPY target/notifygatewaysvc*.jar` syntax when
there is  more that one notifygateway*.jar file that  exists in the target
directory. Thought it was fixed by the docker info change but the same
issue occurs when doing a release because it builds the samplesvc-sources.jar.
This change makes the dockerfile JAR_FILE arg optional to allow the maven
build to provide the full name including version.

The output of the artifacts/tags are:
* A tag called `${project.artifactId}-${project.version}
* 3 artifacts called `${project.artifactId}-${project.version}-${classifier}.jar
* A version of the pom.xml in artifactory in the format `${project.artifactId}-${project.version}.pom`
## Testing
1. Checkout branch
2.  `export ARTIFACTORY_PASSWORD=$REAL_PASSWORD`
3. `mvn -B release:prepare release:perform -Darguments="-Dmaven.javadoc.skip=true"`