### PR TITLE
Update LEGALBASIS to LEGAL_BASIS in classifiers map

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/notify/service/impl/NotifyServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/notify/service/impl/NotifyServiceImpl.java
@@ -57,7 +57,7 @@ public class NotifyServiceImpl implements NotifyService {
     public static final String NOTIFY_SMS_SENT = "Notify Sms Sent";
 
     public static final String REGION_CODE = "REGION";
-    public static final String LEGAL_BASIS = "LEGALBASIS";
+    public static final String LEGAL_BASIS = "LEGAL_BASIS";
 
     @Override
     public ActionFeedback process(final ActionRequest actionRequest) throws NotificationClientException,


### PR DESCRIPTION
To match format in Survey service. currently expects LEGALBASIS to be the classifier attached to the comms template.